### PR TITLE
Update container-instances-quickstart-powershell.md

### DIFF
--- a/articles/container-instances/container-instances-quickstart-powershell.md
+++ b/articles/container-instances/container-instances-quickstart-powershell.md
@@ -49,18 +49,18 @@ $port = New-AzContainerInstancePortObject -Port 80 -Protocol TCP
 Now that you have a resource group and port, you can run a container exposed to the internet in Azure. To create a container instance with Azure PowerShell, you first need to create a `ContainerInstanceObject` by providing a name, image, and port for the container. In this quickstart, you use the public `mcr.microsoft.com/azuredocs/aci-helloworld` image.
 
 ```azurepowershell-interactive
-New-AzContainerInstanceObject -Name myContainer -Image mcr.microsoft.com/azuredocs/aci-helloworld -Port @($port)
+$container = New-AzContainerInstanceObject -Name myContainer -Image mcr.microsoft.com/azuredocs/aci-helloworld -Port @($port)
 ```
 
-Next, use the [New-AzContainerGroup][New-AzContainerGroup] cmdlet. You need to provide a name for the container group, your resource group's name, a location for the container group, the container instance you created, the operating system type, and a unique IP address DNS name label.
+Next, use the [New-AzContainerGroup][New-AzContainerGroup] cmdlet. You need to provide a name for the container group, your resource group's name, a location for the container group, the container instance you just created, the operating system type, and a unique IP address DNS name label.
 
 Execute a command similar to the following to start a container instance. Set a `-IPAddressDnsNameLabel` value that's unique within the Azure region where you create the instance. If you receive a "DNS name label not available" error message, try a different DNS name label.
 
 ```azurepowershell-interactive
-$containerGroup = New-AzContainerInstanceObject -ResourceGroupName myResourceGroup -Name myContainerGroup -Location EastUS -Container myContainer -OsType Windows -IPAddressDnsNameLabel aci-quickstart-win -IpAddressType Public -IPAddressPort @($port)
+$containerGroup = New-AzContainerGroup -ResourceGroupName myResourceGroup -Name myContainerGroup -Location EastUS -Container @($container) -OsType Windows -IPAddressDnsNameLabel aci-quickstart-win -IpAddressType Public -IPAddressPort @($port)
 ```
 
-Within a few seconds, you should receive a response from Azure. The container's `ProvisioningState` is initially **Creating**, but should move to **Succeeded** within a minute or two. Check the deployment state with the [Get-AzContainerGroup][Get-AzContainerGroup] cmdlet:
+Check the deployment state with the [Get-AzContainerGroup][Get-AzContainerGroup] cmdlet:
 
 ```azurepowershell-interactive
 Get-AzContainerGroup -ResourceGroupName myResourceGroup -Name myContainerGroup


### PR DESCRIPTION
Correctly reference New-AzContainerGroup. The snippet incorrectly references New-AzContainerInstanceObject, the above copy on line 55 currently states to use New-AzContainerGroup.

Copy also incorrectly states a status will be returned, so I updated it so that it only instructs the user to check the deployment state with Get-AzContainerGroup.

Container needs to be a container object, not a string

See: https://github.com/MicrosoftDocs/azure-docs/pull/124082 for images as well

